### PR TITLE
Close reasons

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Calling `stream.destroy()` without an error object will close the stream without
 
 ```javascript
 const stream = new WebSocketJSONStream(ws)
-// Closes WebSocket with the code 1005 and the reason ''
+// Closes WebSocket with no status code (1005) and the reason ''
 stream.destroy()
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,15 +31,49 @@ When a WebSocket is closed either by the server or the client, a [`CloseEvent`](
 
 ### `stream.end()`
 
-Calling `stream.end()` will close the WebSocket with the code `1000` and reason `'stream end'`. 1000 indicates a normal closure, meaning that the purpose for which the connection was established has been fulfilled. (https://tools.ietf.org/html/rfc6455#section-7.4.1) The code `1000` may also be used when calling the [`webSocket.close(code)`](https://html.spec.whatwg.org/multipage/web-sockets.html#dom-websocket-close) method of WebSockets in browsers.
+Calling `stream.end()` will close the WebSocket with the code `1000` and reason `'stream end'`. `1000` indicates a normal closure, meaning that the purpose for which the connection was established has been fulfilled. (https://tools.ietf.org/html/rfc6455#section-7.4.1)
 
 Clients may implement this to mean that the server is closing the stream intentionally, and the client should not automatically reconnect.
 
-### `stream.destroy([error])`
+```javascript
+const stream = new WebSocketJSONStream(ws)
+// Closes WebSocket with the code 1000 and the reason 'stream end'
+stream.end()
+```
 
-Calling `stream.destroy()` **without** an error object will close the stream without a code. This results in the client emitting a CloseEvent that has code 1005. 1005 is a reserved value and MUST NOT be set as a status code in a Close control frame by an endpoint. It is designated for use in applications expecting a status code to indicate that no status code was actually present. (https://tools.ietf.org/html/rfc6455#section-7.4.1) Calling `webSocket.close()` with no arguments will produce a CloseEvent with the code `1005`. A reason string cannot be provided together with the code `1005`.
+The code `1000` may also be used when calling the [`webSocket.close(code)`](https://html.spec.whatwg.org/multipage/web-sockets.html#dom-websocket-close) method of WebSockets in browsers.
 
-Calling `stream.destroy(error)` **with** an error will emit an `'error'` event and close the stream with the code `1011` and reason `'stream error'` by default. 1011 indicates that a remote endpoint is terminating the connection because it encountered an unexpected condition that prevented it from fulfilling the request. (http://www.rfc-editor.org/errata_search.php?eid=3227) The code `1011` cannot be used when calling the `webSocket.close(code)` method of WebSockets in browsers.
+### `stream.destroy()`
+
+Calling `stream.destroy()` without an error object will close the stream without a code. This results in the client emitting a CloseEvent that has code `1005` and reason `''`. `1005` is a reserved value and MUST NOT be set as a status code in a Close control frame by an endpoint. It is designated for use in applications expecting a status code to indicate that no status code was actually present. (https://tools.ietf.org/html/rfc6455#section-7.4.1)
+
+```javascript
+const stream = new WebSocketJSONStream(ws)
+// Closes WebSocket with the code 1005 and the reason ''
+stream.destroy()
+```
+
+Calling `webSocket.close()` method of WebSockets in browsers without any arguments will produce a CloseEvent with the code `1005`. A reason string cannot be provided together with the code `1005`.
+
+### `stream.destroy(error)`
+
+Calling `stream.destroy(error)` with an error will emit an `'error'` event and close the stream with the code `1011` and reason `'stream error'` by default. `1011` indicates that a remote endpoint is terminating the connection because it encountered an unexpected condition that prevented it from fulfilling the request. (http://www.rfc-editor.org/errata_search.php?eid=3227)
+
+```javascript
+const stream = new WebSocketJSONStream(ws)
+stream.on('error', (error) => {
+  // Error event must be handled, or it will be throw when calling
+  // stream.destroy() with an error argument
+})
+
+// Closes WebSocket with the code 1011 and the reason 'stream error'
+const error = new Error('Unexpected server error')
+stream.destroy(error)
+```
+
+The code `1011` cannot be used when calling the `webSocket.close(code)` method of WebSockets in browsers.
+
+### `error.closeCode` and `error.closeReason`
 
 Custom close code and reason values may be sent by setting `error.closeCode` or `error.closeReason` properties on the error argument passed to `stream.destroy(error)`. For example:
 
@@ -68,3 +102,5 @@ error.closeCode = 4000
 error.closeReason = 'custom reason'
 stream.destroy(error)
 ```
+
+Browser WebSockets allow custom close codes between 3000 and 4999.

--- a/README.md
+++ b/README.md
@@ -22,3 +22,49 @@ new WebSocket.Server({ server }).on('connection', ws => {
 ```
 
 See [example.js](./example.js) for a working usage example.
+
+## Closing a WebSocket via its stream
+
+Calling [`stream.end()`](https://nodejs.org/api/stream.html#stream_writable_end_chunk_encoding_callback) or [`stream.destroy()`](https://nodejs.org/api/stream.html#stream_writable_destroy_error) will close the WebSocket connection.
+
+When a WebSocket is closed either by the server or the client, a [`CloseEvent`](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent) will be emmitted. CloseEvents have both a numeric `code` and a string `reason` property that may be used to indicate the type of closure.
+
+### `stream.end()`
+
+Calling `stream.end()` will close the WebSocket with the code `1000` and reason `'stream end'`. 1000 indicates a normal closure, meaning that the purpose for which the connection was established has been fulfilled. (https://tools.ietf.org/html/rfc6455#section-7.4.1) The code `1000` may also be used when calling the [`webSocket.close(code)`](https://html.spec.whatwg.org/multipage/web-sockets.html#dom-websocket-close) method of WebSockets in browsers.
+
+Clients may implement this to mean that the server is closing the stream intentionally, and the client should not automatically reconnect.
+
+### `stream.destroy([error])`
+
+Calling `stream.destroy()` **without** an error object will close the stream without a code. This results in the client emitting a CloseEvent that has code 1005. 1005 is a reserved value and MUST NOT be set as a status code in a Close control frame by an endpoint. It is designated for use in applications expecting a status code to indicate that no status code was actually present. (https://tools.ietf.org/html/rfc6455#section-7.4.1) Calling `webSocket.close()` with no arguments will produce a CloseEvent with the code `1005`. A reason string cannot be provided together with the code `1005`.
+
+Calling `stream.destroy(error)` **with** an error will emit an `'error'` event and close the stream with the code `1011` and reason `'stream error'` by default. 1011 indicates that a remote endpoint is terminating the connection because it encountered an unexpected condition that prevented it from fulfilling the request. (http://www.rfc-editor.org/errata_search.php?eid=3227) The code `1011` cannot be used when calling the `webSocket.close(code)` method of WebSockets in browsers.
+
+Custom close code and reason values may be sent by setting `error.closeCode` or `error.closeReason` properties on the error argument passed to `stream.destroy(error)`. For example:
+
+```javascript
+const stream = new WebSocketJSONStream(ws)
+stream.on('error', (error) => {
+  // Error event must be handled, or it will be throw when calling
+  // stream.destroy() with an error argument
+})
+
+// Example of extending from Error and adding additional properties
+class CustomStreamError extends Error {
+    constructor(message) {
+        super(message)
+        this.name = this.constructor.name
+        Error.captureStackTrace(this, this.constructor)
+        this.closeCode = null
+        this.closeReason = null
+    }
+}
+
+// Closes WebSocket with the code 4000 and the reason 'custom reason'.
+// error.message is not sent to the client
+const error = new CustomStreamError('Example error')
+error.closeCode = 4000
+error.closeReason = 'custom reason'
+stream.destroy(error)
+```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See [example.js](./example.js) for a working usage example.
 
 Calling [`stream.end()`](https://nodejs.org/api/stream.html#stream_writable_end_chunk_encoding_callback) or [`stream.destroy()`](https://nodejs.org/api/stream.html#stream_writable_destroy_error) will close the WebSocket connection.
 
-When a WebSocket is closed either by the server or the client, a [`CloseEvent`](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent) will be emmitted. CloseEvents have both a numeric `code` and a string `reason` property that may be used to indicate the type of closure.
+When a WebSocket is closed either by the server or the client, a [`CloseEvent`](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent) will be emitted. CloseEvents have both a numeric `code` and a string `reason` property that may be used to indicate the type of closure.
 
 ### `stream.end()`
 

--- a/destroy.js
+++ b/destroy.js
@@ -1,0 +1,91 @@
+// Copied from:
+// https://github.com/nodejs/node/blob/f5a2167eb5565b84e068b385dc22c5e74f543d1b/lib/internal/streams/destroy.js
+
+'use strict';
+
+// undocumented cb() API, needed for core, not for public API
+function destroy(err, cb) {
+  const readableDestroyed = this._readableState &&
+    this._readableState.destroyed;
+  const writableDestroyed = this._writableState &&
+    this._writableState.destroyed;
+
+  if (readableDestroyed || writableDestroyed) {
+    if (cb) {
+      cb(err);
+    } else if (err &&
+               (!this._writableState || !this._writableState.errorEmitted)) {
+      process.nextTick(emitErrorNT, this, err);
+    }
+    return this;
+  }
+
+  // we set destroyed to true before firing error callbacks in order
+  // to make it re-entrance safe in case destroy() is called within callbacks
+
+  if (this._readableState) {
+    this._readableState.destroyed = true;
+  }
+
+  // if this is a duplex stream mark the writable part as destroyed as well
+  if (this._writableState) {
+    this._writableState.destroyed = true;
+  }
+
+  this._destroy(err || null, (err) => {
+    if (!cb && err) {
+      process.nextTick(emitErrorAndCloseNT, this, err);
+      if (this._writableState) {
+        this._writableState.errorEmitted = true;
+      }
+    } else if (cb) {
+      process.nextTick(emitCloseNT, this);
+      cb(err);
+    } else {
+      process.nextTick(emitCloseNT, this);
+    }
+  });
+
+  return this;
+}
+
+function emitErrorAndCloseNT(self, err) {
+  emitErrorNT(self, err);
+  emitCloseNT(self);
+}
+
+function emitCloseNT(self) {
+  if (self._writableState && !self._writableState.emitClose)
+    return;
+  if (self._readableState && !self._readableState.emitClose)
+    return;
+  self.emit('close');
+}
+
+function undestroy() {
+  if (this._readableState) {
+    this._readableState.destroyed = false;
+    this._readableState.reading = false;
+    this._readableState.ended = false;
+    this._readableState.endEmitted = false;
+  }
+
+  if (this._writableState) {
+    this._writableState.destroyed = false;
+    this._writableState.ended = false;
+    this._writableState.ending = false;
+    this._writableState.finalCalled = false;
+    this._writableState.prefinished = false;
+    this._writableState.finished = false;
+    this._writableState.errorEmitted = false;
+  }
+}
+
+function emitErrorNT(self, err) {
+  self.emit('error', err);
+}
+
+module.exports = {
+  destroy,
+  undestroy
+};

--- a/destroy.js
+++ b/destroy.js
@@ -3,6 +3,7 @@
 
 'use strict';
 
+/* istanbul ignore next */
 // undocumented cb() API, needed for core, not for public API
 function destroy(err, cb) {
   const readableDestroyed = this._readableState &&
@@ -49,11 +50,13 @@ function destroy(err, cb) {
   return this;
 }
 
+/* istanbul ignore next */
 function emitErrorAndCloseNT(self, err) {
   emitErrorNT(self, err);
   emitCloseNT(self);
 }
 
+/* istanbul ignore next */
 function emitCloseNT(self) {
   if (self._writableState && !self._writableState.emitClose)
     return;
@@ -62,30 +65,11 @@ function emitCloseNT(self) {
   self.emit('close');
 }
 
-function undestroy() {
-  if (this._readableState) {
-    this._readableState.destroyed = false;
-    this._readableState.reading = false;
-    this._readableState.ended = false;
-    this._readableState.endEmitted = false;
-  }
-
-  if (this._writableState) {
-    this._writableState.destroyed = false;
-    this._writableState.ended = false;
-    this._writableState.ending = false;
-    this._writableState.finalCalled = false;
-    this._writableState.prefinished = false;
-    this._writableState.finished = false;
-    this._writableState.errorEmitted = false;
-  }
-}
-
+/* istanbul ignore next */
 function emitErrorNT(self, err) {
   self.emit('error', err);
 }
 
 module.exports = {
-  destroy,
-  undestroy
+  destroy
 };

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const Duplex = require('stream').Duplex
 const WebSocket = require('ws')
+const destroy = require('./destroy').destroy
 const noop = function () {}
 
 module.exports = class WebSocketJSONStream extends Duplex {
@@ -42,7 +43,7 @@ module.exports = class WebSocketJSONStream extends Duplex {
 
         // Required by nodejs 6.X.X which does not support `destroy`.
         if (typeof this.destroy !== 'function') {
-            this.destroy = () => this._closeWebSocket(noop)
+            this.destroy = destroy
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -3,6 +3,11 @@ const WebSocket = require('ws')
 const destroy = require('./destroy').destroy
 const noop = function () {}
 
+const NORMAL_CLOSURE_CODE = 1000
+const NORMAL_CLOSURE_REASON = 'stream end'
+const INTERNAL_ERROR_CODE = 1011
+const INTERNAL_ERROR_REASON = 'stream error'
+
 module.exports = class WebSocketJSONStream extends Duplex {
     constructor(ws) {
         super({
@@ -70,37 +75,43 @@ module.exports = class WebSocketJSONStream extends Duplex {
     }
 
     _destroy(error, callback) {
-        // Calling destroy without an error object will close the stream
-        // without a code. This results in the client emitting a CloseEvent
-        // that has code 1005.
-        //
-        // 1005 is a reserved value and MUST NOT be set as a status code in a
-        // Close control frame by an endpoint.  It is designated for use in
-        // applications expecting a status code to indicate that no status
-        // code was actually present.
-        // https://tools.ietf.org/html/rfc6455#section-7.4.1
+
+        /*
+         * Calling destroy without an error object will close the stream
+         * without a code. This results in the client emitting a CloseEvent
+         * that has code 1005.
+         *
+         * 1005 is a reserved value and MUST NOT be set as a status code in a
+         * Close control frame by an endpoint.  It is designated for use in
+         * applications expecting a status code to indicate that no status
+         * code was actually present.
+         * https://tools.ietf.org/html/rfc6455#section-7.4.1
+         */
         let code
         let reason
 
         if (error) {
-            // 1011 indicates that a remote endpoint is terminating the
-            // connection because it encountered an unexpected condition that
-            // prevented it from fulfilling the request.
-            // http://www.rfc-editor.org/errata_search.php?eid=3227
-            code = error.closeCode || 1011
-            reason = error.closeReason || 'stream error'
+
+            /*
+             * 1011 indicates that a remote endpoint is terminating the
+             * connection because it encountered an unexpected condition that
+             * prevented it from fulfilling the request.
+             * http://www.rfc-editor.org/errata_search.php?eid=3227
+             */
+            code = error.closeCode || INTERNAL_ERROR_CODE
+            reason = error.closeReason || INTERNAL_ERROR_REASON
         }
         this._closeWebSocket(code, reason, () => callback(error))
     }
 
     _closeOnStreamEnd(callback) {
-        // 1000 indicates a normal closure, meaning that the purpose for which
-        // the connection was established has been fulfilled.
-        // https://tools.ietf.org/html/rfc6455#section-7.4.1
-        const code = 1000
-        const reason = 'stream end'
 
-        this._closeWebSocket(code, reason, callback)
+        /*
+         * 1000 indicates a normal closure, meaning that the purpose for which
+         * the connection was established has been fulfilled.
+         * https://tools.ietf.org/html/rfc6455#section-7.4.1
+         */
+        this._closeWebSocket(NORMAL_CLOSURE_CODE, NORMAL_CLOSURE_REASON, callback)
     }
 
     _closeWebSocket(code, reason, callback) {

--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ module.exports = class WebSocketJSONStream extends Duplex {
         // Required by nodejs 6.X.X which does not support `_final`.
         this.once('finish', () => this._closeOnStreamEnd(noop))
 
+        /* istanbul ignore next */
         // Required by nodejs 6.X.X which does not support `destroy`.
         if (typeof this.destroy !== 'function') {
             this.destroy = destroy

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = class WebSocketJSONStream extends Duplex {
         })
 
         // Required by nodejs 6.X.X which does not support `_final`.
-        this.once('finish', () => this._closeWebSocket(noop))
+        this.once('finish', () => this._closeOnStreamEnd(noop))
 
         // Required by nodejs 6.X.X which does not support `destroy`.
         if (typeof this.destroy !== 'function') {
@@ -66,22 +66,52 @@ module.exports = class WebSocketJSONStream extends Duplex {
     }
 
     _final(callback) {
-        this._closeWebSocket(callback)
+        this._closeOnStreamEnd(callback)
     }
 
     _destroy(error, callback) {
-        this._closeWebSocket(() => callback(error))
+        // Calling destroy without an error object will close the stream
+        // without a code. This results in the client emitting a CloseEvent
+        // that has code 1005.
+        //
+        // 1005 is a reserved value and MUST NOT be set as a status code in a
+        // Close control frame by an endpoint.  It is designated for use in
+        // applications expecting a status code to indicate that no status
+        // code was actually present.
+        // https://tools.ietf.org/html/rfc6455#section-7.4.1
+        let code
+        let reason
+
+        if (error) {
+            // 1011 indicates that a remote endpoint is terminating the
+            // connection because it encountered an unexpected condition that
+            // prevented it from fulfilling the request.
+            // http://www.rfc-editor.org/errata_search.php?eid=3227
+            code = error.closeCode || 1011
+            reason = error.closeReason || 'stream error'
+        }
+        this._closeWebSocket(code, reason, () => callback(error))
     }
 
-    _closeWebSocket(callback) {
+    _closeOnStreamEnd(callback) {
+        // 1000 indicates a normal closure, meaning that the purpose for which
+        // the connection was established has been fulfilled.
+        // https://tools.ietf.org/html/rfc6455#section-7.4.1
+        const code = 1000
+        const reason = 'stream end'
+
+        this._closeWebSocket(code, reason, callback)
+    }
+
+    _closeWebSocket(code, reason, callback) {
         switch (this.ws.readyState) {
             case WebSocket.CONNECTING:
-                this.ws.once('error', () => this._closeWebSocket(callback))
-                this.ws.once('open', () => this._closeWebSocket(callback))
+                this.ws.once('error', () => this._closeWebSocket(code, reason, callback))
+                this.ws.once('open', () => this._closeWebSocket(code, reason, callback))
                 break
             case WebSocket.OPEN:
                 this.ws.once('close', () => callback())
-                this.ws.close()
+                this.ws.close(code, reason)
                 break
             case WebSocket.CLOSING:
                 this.ws.once('close', () => callback())

--- a/test/WebSocketJSONStream.test.js
+++ b/test/WebSocketJSONStream.test.js
@@ -2,6 +2,7 @@ const assert = require('chai').assert
 const http = require('http')
 const WebSocket = require('ws')
 const WebSocketJSONStream = require('..')
+const testCloseStatus = require('./close-status')
 
 const handler = (done, code) => (...args) => {
     try {
@@ -229,96 +230,5 @@ describe('WebSocketJSONStream', function () {
         clientWebSocket.on('open', () => clientWebSocket.close())
     })
 
-    it('should emit CloseEvent with code 1000 and reason "stream end" on clientStream.end()', function (done) {
-        this.clientWebSocket.onclose = (event) => {
-            assert.equal(event.code, 1000)
-            assert.equal(event.reason, 'stream end')
-            done()
-        }
-        this.clientStream.end()
-    })
-    it('should emit CloseEvent with code 1000 and reason "stream end" on serverStream.end()', function (done) {
-        this.clientWebSocket.onclose = (event) => {
-            assert.equal(event.code, 1000)
-            assert.equal(event.reason, 'stream end')
-            done()
-        }
-        this.serverStream.end()
-    })
-    it('should emit CloseEvent with code 1005 and reason "" on clientStream.destroy()', function (done) {
-        this.clientWebSocket.onclose = (event) => {
-            assert.equal(event.code, 1005)
-            assert.equal(event.reason, '')
-            done()
-        }
-        this.clientStream.destroy()
-    })
-    it('should emit CloseEvent with code 1005 and reason "" on serverStream.destroy()', function (done) {
-        this.clientWebSocket.onclose = (event) => {
-            assert.equal(event.code, 1005)
-            assert.equal(event.reason, '')
-            done()
-        }
-        this.serverStream.destroy()
-    })
-    it('should emit CloseEvent with code 1011 and reason "stream error" on clientStream.destroy(error)', function (done) {
-        this.clientWebSocket.onclose = (event) => {
-            assert.equal(event.code, 1011)
-            assert.equal(event.reason, 'stream error')
-            done()
-        }
-        const error = new Error('Test error')
-        this.clientStream.on('error', e => {})
-        this.clientStream.destroy(error)
-    })
-    it('should emit CloseEvent with code 1011 and reason "stream error" on serverStream.destroy(error)', function (done) {
-        this.clientWebSocket.onclose = (event) => {
-            assert.equal(event.code, 1011)
-            assert.equal(event.reason, 'stream error')
-            done()
-        }
-        const error = new Error('Test error')
-        this.serverStream.on('error', e => {})
-        this.serverStream.destroy(error)
-    })
-    it('should emit CloseEvent with code from error.closeCode on clientStream.destroy(error)', function (done) {
-        this.clientWebSocket.onclose = (event) => {
-            assert.equal(event.code, 4000)
-            done()
-        }
-        const error = new Error('Test error')
-        error.closeCode = 4000
-        this.clientStream.on('error', e => {})
-        this.clientStream.destroy(error)
-    })
-    it('should emit CloseEvent with code from error.closeCode on serverStream.destroy(error)', function (done) {
-        this.clientWebSocket.onclose = (event) => {
-            assert.equal(event.code, 4000)
-            done()
-        }
-        const error = new Error('Test error')
-        error.closeCode = 4000
-        this.serverStream.on('error', e => {})
-        this.serverStream.destroy(error)
-    })
-    it('should emit CloseEvent with reason from error.closeReason on clientStream.destroy(error)', function (done) {
-        this.clientWebSocket.onclose = (event) => {
-            assert.equal(event.reason, 'custom reason')
-            done()
-        }
-        const error = new Error('Test error')
-        error.closeReason = 'custom reason'
-        this.clientStream.on('error', e => {})
-        this.clientStream.destroy(error)
-    })
-    it('should emit CloseEvent with reason from error.closeReason on serverStream.destroy(error)', function (done) {
-        this.clientWebSocket.onclose = (event) => {
-            assert.equal(event.reason, 'custom reason')
-            done()
-        }
-        const error = new Error('Test error')
-        error.closeReason = 'custom reason'
-        this.serverStream.on('error', e => {})
-        this.serverStream.destroy(error)
-    })
+    testCloseStatus()
 })

--- a/test/WebSocketJSONStream.test.js
+++ b/test/WebSocketJSONStream.test.js
@@ -228,4 +228,97 @@ describe('WebSocketJSONStream', function () {
         })
         clientWebSocket.on('open', () => clientWebSocket.close())
     })
+
+    it('should emit CloseEvent with code 1000 and reason "stream end" on clientStream.end()', function (done) {
+        this.clientWebSocket.onclose = (event) => {
+            assert.equal(event.code, 1000)
+            assert.equal(event.reason, 'stream end')
+            done()
+        }
+        this.clientStream.end()
+    })
+    it('should emit CloseEvent with code 1000 and reason "stream end" on serverStream.end()', function (done) {
+        this.clientWebSocket.onclose = (event) => {
+            assert.equal(event.code, 1000)
+            assert.equal(event.reason, 'stream end')
+            done()
+        }
+        this.serverStream.end()
+    })
+    it('should emit CloseEvent with code 1005 and reason "" on clientStream.destroy()', function (done) {
+        this.clientWebSocket.onclose = (event) => {
+            assert.equal(event.code, 1005)
+            assert.equal(event.reason, '')
+            done()
+        }
+        this.clientStream.destroy()
+    })
+    it('should emit CloseEvent with code 1005 and reason "" on serverStream.destroy()', function (done) {
+        this.clientWebSocket.onclose = (event) => {
+            assert.equal(event.code, 1005)
+            assert.equal(event.reason, '')
+            done()
+        }
+        this.serverStream.destroy()
+    })
+    it('should emit CloseEvent with code 1011 and reason "stream error" on clientStream.destroy(error)', function (done) {
+        this.clientWebSocket.onclose = (event) => {
+            assert.equal(event.code, 1011)
+            assert.equal(event.reason, 'stream error')
+            done()
+        }
+        const error = new Error('Test error')
+        this.clientStream.on('error', e => {})
+        this.clientStream.destroy(error)
+    })
+    it('should emit CloseEvent with code 1011 and reason "stream error" on serverStream.destroy(error)', function (done) {
+        this.clientWebSocket.onclose = (event) => {
+            assert.equal(event.code, 1011)
+            assert.equal(event.reason, 'stream error')
+            done()
+        }
+        const error = new Error('Test error')
+        this.serverStream.on('error', e => {})
+        this.serverStream.destroy(error)
+    })
+    it('should emit CloseEvent with code from error.closeCode on clientStream.destroy(error)', function (done) {
+        this.clientWebSocket.onclose = (event) => {
+            assert.equal(event.code, 4000)
+            done()
+        }
+        const error = new Error('Test error')
+        error.closeCode = 4000
+        this.clientStream.on('error', e => {})
+        this.clientStream.destroy(error)
+    })
+    it('should emit CloseEvent with code from error.closeCode on serverStream.destroy(error)', function (done) {
+        this.clientWebSocket.onclose = (event) => {
+            assert.equal(event.code, 4000)
+            done()
+        }
+        const error = new Error('Test error')
+        error.closeCode = 4000
+        this.serverStream.on('error', e => {})
+        this.serverStream.destroy(error)
+    })
+    it('should emit CloseEvent with reason from error.closeReason on clientStream.destroy(error)', function (done) {
+        this.clientWebSocket.onclose = (event) => {
+            assert.equal(event.reason, 'custom reason')
+            done()
+        }
+        const error = new Error('Test error')
+        error.closeReason = 'custom reason'
+        this.clientStream.on('error', e => {})
+        this.clientStream.destroy(error)
+    })
+    it('should emit CloseEvent with reason from error.closeReason on serverStream.destroy(error)', function (done) {
+        this.clientWebSocket.onclose = (event) => {
+            assert.equal(event.reason, 'custom reason')
+            done()
+        }
+        const error = new Error('Test error')
+        error.closeReason = 'custom reason'
+        this.serverStream.on('error', e => {})
+        this.serverStream.destroy(error)
+    })
 })

--- a/test/close-status.js
+++ b/test/close-status.js
@@ -6,8 +6,9 @@ const INTERNAL_ERROR_CODE = 1011
 const CUSTOM_CODE = 4000
 
 module.exports = function() {
-    ['clientWebSocket', 'serverWebSocket'].forEach(webSocketName => {
-        describe(webSocketName + ' CloseEvent', function () {
+    [ 'clientWebSocket', 'serverWebSocket' ].forEach(webSocketName => {
+        /* eslint no-invalid-this: "off" */
+        describe(`${webSocketName} CloseEvent`, function () {
             it('is emitted with code 1000 and reason "stream end" on clientStream.end()', function (done) {
                 this[webSocketName].addEventListener('close', event => {
                     assert.equal(event.code, NORMAL_CLOSURE_CODE)
@@ -102,7 +103,7 @@ module.exports = function() {
             })
         })
 
-        describe(webSocketName + ' "close" event', function () {
+        describe(`${webSocketName} "close" event`, function () {
             it('is emitted with code 1000 and reason "stream end" on clientStream.end()', function (done) {
                 this[webSocketName].on('close', (code, reason) => {
                     assert.equal(code, NORMAL_CLOSURE_CODE)
@@ -156,7 +157,7 @@ module.exports = function() {
                 this.serverStream.destroy(error)
             })
             it('is emitted with code from error.closeCode on clientStream.destroy(error)', function (done) {
-                this[webSocketName].on('close', (code) => {
+                this[webSocketName].on('close', code => {
                     assert.equal(code, CUSTOM_CODE)
                     done()
                 })
@@ -166,7 +167,7 @@ module.exports = function() {
                 this.clientStream.destroy(error)
             })
             it('is emitted with code from error.closeCode on serverStream.destroy(error)', function (done) {
-                this[webSocketName].on('close', (code) => {
+                this[webSocketName].on('close', code => {
                     assert.equal(code, CUSTOM_CODE)
                     done()
                 })

--- a/test/close-status.js
+++ b/test/close-status.js
@@ -1,0 +1,101 @@
+const assert = require('chai').assert
+
+const NORMAL_CLOSURE_CODE = 1000
+const NO_STATUS_CODE = 1005
+const INTERNAL_ERROR_CODE = 1011
+const CUSTOM_CODE = 4000
+
+module.exports = function() {
+    it('should emit CloseEvent with code 1000 and reason "stream end" on clientStream.end()', function (done) {
+        this.clientWebSocket.onclose = event => {
+            assert.equal(event.code, NORMAL_CLOSURE_CODE)
+            assert.equal(event.reason, 'stream end')
+            done()
+        }
+        this.clientStream.end()
+    })
+    it('should emit CloseEvent with code 1000 and reason "stream end" on serverStream.end()', function (done) {
+        this.clientWebSocket.onclose = event => {
+            assert.equal(event.code, NORMAL_CLOSURE_CODE)
+            assert.equal(event.reason, 'stream end')
+            done()
+        }
+        this.serverStream.end()
+    })
+    it('should emit CloseEvent with code 1005 and reason "" on clientStream.destroy()', function (done) {
+        this.clientWebSocket.onclose = event => {
+            assert.equal(event.code, NO_STATUS_CODE)
+            assert.equal(event.reason, '')
+            done()
+        }
+        this.clientStream.destroy()
+    })
+    it('should emit CloseEvent with code 1005 and reason "" on serverStream.destroy()', function (done) {
+        this.clientWebSocket.onclose = event => {
+            assert.equal(event.code, NO_STATUS_CODE)
+            assert.equal(event.reason, '')
+            done()
+        }
+        this.serverStream.destroy()
+    })
+    it('should emit CloseEvent with code 1011 and reason "stream error" on clientStream.destroy(error)', function (done) {
+        this.clientWebSocket.onclose = event => {
+            assert.equal(event.code, INTERNAL_ERROR_CODE)
+            assert.equal(event.reason, 'stream error')
+            done()
+        }
+        const error = new Error('Test error')
+        this.clientStream.on('error', () => {})
+        this.clientStream.destroy(error)
+    })
+    it('should emit CloseEvent with code 1011 and reason "stream error" on serverStream.destroy(error)', function (done) {
+        this.clientWebSocket.onclose = event => {
+            assert.equal(event.code, INTERNAL_ERROR_CODE)
+            assert.equal(event.reason, 'stream error')
+            done()
+        }
+        const error = new Error('Test error')
+        this.serverStream.on('error', () => {})
+        this.serverStream.destroy(error)
+    })
+    it('should emit CloseEvent with code from error.closeCode on clientStream.destroy(error)', function (done) {
+        this.clientWebSocket.onclose = event => {
+            assert.equal(event.code, CUSTOM_CODE)
+            done()
+        }
+        const error = new Error('Test error')
+        error.closeCode = CUSTOM_CODE
+        this.clientStream.on('error', () => {})
+        this.clientStream.destroy(error)
+    })
+    it('should emit CloseEvent with code from error.closeCode on serverStream.destroy(error)', function (done) {
+        this.clientWebSocket.onclose = event => {
+            assert.equal(event.code, CUSTOM_CODE)
+            done()
+        }
+        const error = new Error('Test error')
+        error.closeCode = CUSTOM_CODE
+        this.serverStream.on('error', () => {})
+        this.serverStream.destroy(error)
+    })
+    it('should emit CloseEvent with reason from error.closeReason on clientStream.destroy(error)', function (done) {
+        this.clientWebSocket.onclose = event => {
+            assert.equal(event.reason, 'custom reason')
+            done()
+        }
+        const error = new Error('Test error')
+        error.closeReason = 'custom reason'
+        this.clientStream.on('error', () => {})
+        this.clientStream.destroy(error)
+    })
+    it('should emit CloseEvent with reason from error.closeReason on serverStream.destroy(error)', function (done) {
+        this.clientWebSocket.onclose = event => {
+            assert.equal(event.reason, 'custom reason')
+            done()
+        }
+        const error = new Error('Test error')
+        error.closeReason = 'custom reason'
+        this.serverStream.on('error', () => {})
+        this.serverStream.destroy(error)
+    })
+}

--- a/test/close-status.js
+++ b/test/close-status.js
@@ -6,96 +6,195 @@ const INTERNAL_ERROR_CODE = 1011
 const CUSTOM_CODE = 4000
 
 module.exports = function() {
-    it('should emit CloseEvent with code 1000 and reason "stream end" on clientStream.end()', function (done) {
-        this.clientWebSocket.onclose = event => {
-            assert.equal(event.code, NORMAL_CLOSURE_CODE)
-            assert.equal(event.reason, 'stream end')
-            done()
-        }
-        this.clientStream.end()
-    })
-    it('should emit CloseEvent with code 1000 and reason "stream end" on serverStream.end()', function (done) {
-        this.clientWebSocket.onclose = event => {
-            assert.equal(event.code, NORMAL_CLOSURE_CODE)
-            assert.equal(event.reason, 'stream end')
-            done()
-        }
-        this.serverStream.end()
-    })
-    it('should emit CloseEvent with code 1005 and reason "" on clientStream.destroy()', function (done) {
-        this.clientWebSocket.onclose = event => {
-            assert.equal(event.code, NO_STATUS_CODE)
-            assert.equal(event.reason, '')
-            done()
-        }
-        this.clientStream.destroy()
-    })
-    it('should emit CloseEvent with code 1005 and reason "" on serverStream.destroy()', function (done) {
-        this.clientWebSocket.onclose = event => {
-            assert.equal(event.code, NO_STATUS_CODE)
-            assert.equal(event.reason, '')
-            done()
-        }
-        this.serverStream.destroy()
-    })
-    it('should emit CloseEvent with code 1011 and reason "stream error" on clientStream.destroy(error)', function (done) {
-        this.clientWebSocket.onclose = event => {
-            assert.equal(event.code, INTERNAL_ERROR_CODE)
-            assert.equal(event.reason, 'stream error')
-            done()
-        }
-        const error = new Error('Test error')
-        this.clientStream.on('error', () => {})
-        this.clientStream.destroy(error)
-    })
-    it('should emit CloseEvent with code 1011 and reason "stream error" on serverStream.destroy(error)', function (done) {
-        this.clientWebSocket.onclose = event => {
-            assert.equal(event.code, INTERNAL_ERROR_CODE)
-            assert.equal(event.reason, 'stream error')
-            done()
-        }
-        const error = new Error('Test error')
-        this.serverStream.on('error', () => {})
-        this.serverStream.destroy(error)
-    })
-    it('should emit CloseEvent with code from error.closeCode on clientStream.destroy(error)', function (done) {
-        this.clientWebSocket.onclose = event => {
-            assert.equal(event.code, CUSTOM_CODE)
-            done()
-        }
-        const error = new Error('Test error')
-        error.closeCode = CUSTOM_CODE
-        this.clientStream.on('error', () => {})
-        this.clientStream.destroy(error)
-    })
-    it('should emit CloseEvent with code from error.closeCode on serverStream.destroy(error)', function (done) {
-        this.clientWebSocket.onclose = event => {
-            assert.equal(event.code, CUSTOM_CODE)
-            done()
-        }
-        const error = new Error('Test error')
-        error.closeCode = CUSTOM_CODE
-        this.serverStream.on('error', () => {})
-        this.serverStream.destroy(error)
-    })
-    it('should emit CloseEvent with reason from error.closeReason on clientStream.destroy(error)', function (done) {
-        this.clientWebSocket.onclose = event => {
-            assert.equal(event.reason, 'custom reason')
-            done()
-        }
-        const error = new Error('Test error')
-        error.closeReason = 'custom reason'
-        this.clientStream.on('error', () => {})
-        this.clientStream.destroy(error)
-    })
-    it('should emit CloseEvent with reason from error.closeReason on serverStream.destroy(error)', function (done) {
-        this.clientWebSocket.onclose = event => {
-            assert.equal(event.reason, 'custom reason')
-            done()
-        }
-        const error = new Error('Test error')
-        error.closeReason = 'custom reason'
-        this.serverStream.on('error', () => {})
-        this.serverStream.destroy(error)
+    ['clientWebSocket', 'serverWebSocket'].forEach(webSocketName => {
+        describe(webSocketName + ' CloseEvent', function () {
+            it('is emitted with code 1000 and reason "stream end" on clientStream.end()', function (done) {
+                this[webSocketName].addEventListener('close', event => {
+                    assert.equal(event.code, NORMAL_CLOSURE_CODE)
+                    assert.equal(event.reason, 'stream end')
+                    done()
+                })
+                this.clientStream.end()
+            })
+            it('is emitted with code 1000 and reason "stream end" on serverStream.end()', function (done) {
+                this[webSocketName].addEventListener('close', event => {
+                    assert.equal(event.code, NORMAL_CLOSURE_CODE)
+                    assert.equal(event.reason, 'stream end')
+                    done()
+                })
+                this.serverStream.end()
+            })
+            it('is emitted with code 1005 and reason "" on clientStream.destroy()', function (done) {
+                this[webSocketName].addEventListener('close', event => {
+                    assert.equal(event.code, NO_STATUS_CODE)
+                    assert.equal(event.reason, '')
+                    done()
+                })
+                this.clientStream.destroy()
+            })
+            it('is emitted with code 1005 and reason "" on serverStream.destroy()', function (done) {
+                this[webSocketName].addEventListener('close', event => {
+                    assert.equal(event.code, NO_STATUS_CODE)
+                    assert.equal(event.reason, '')
+                    done()
+                })
+                this.serverStream.destroy()
+            })
+            it('is emitted with code 1011 and reason "stream error" on clientStream.destroy(error)', function (done) {
+                this[webSocketName].addEventListener('close', event => {
+                    assert.equal(event.code, INTERNAL_ERROR_CODE)
+                    assert.equal(event.reason, 'stream error')
+                    done()
+                })
+                const error = new Error('Test error')
+                this.clientStream.on('error', () => {})
+                this.clientStream.destroy(error)
+            })
+            it('is emitted with code 1011 and reason "stream error" on serverStream.destroy(error)', function (done) {
+                this[webSocketName].addEventListener('close', event => {
+                    assert.equal(event.code, INTERNAL_ERROR_CODE)
+                    assert.equal(event.reason, 'stream error')
+                    done()
+                })
+                const error = new Error('Test error')
+                this.serverStream.on('error', () => {})
+                this.serverStream.destroy(error)
+            })
+            it('is emitted with code from error.closeCode on clientStream.destroy(error)', function (done) {
+                this[webSocketName].addEventListener('close', event => {
+                    assert.equal(event.code, CUSTOM_CODE)
+                    done()
+                })
+                const error = new Error('Test error')
+                error.closeCode = CUSTOM_CODE
+                this.clientStream.on('error', () => {})
+                this.clientStream.destroy(error)
+            })
+            it('is emitted with code from error.closeCode on serverStream.destroy(error)', function (done) {
+                this[webSocketName].addEventListener('close', event => {
+                    assert.equal(event.code, CUSTOM_CODE)
+                    done()
+                })
+                const error = new Error('Test error')
+                error.closeCode = CUSTOM_CODE
+                this.serverStream.on('error', () => {})
+                this.serverStream.destroy(error)
+            })
+            it('is emitted with reason from error.closeReason on clientStream.destroy(error)', function (done) {
+                this[webSocketName].addEventListener('close', event => {
+                    assert.equal(event.reason, 'custom reason')
+                    done()
+                })
+                const error = new Error('Test error')
+                error.closeReason = 'custom reason'
+                this.clientStream.on('error', () => {})
+                this.clientStream.destroy(error)
+            })
+            it('is emitted with reason from error.closeReason on serverStream.destroy(error)', function (done) {
+                this[webSocketName].addEventListener('close', event => {
+                    assert.equal(event.reason, 'custom reason')
+                    done()
+                })
+                const error = new Error('Test error')
+                error.closeReason = 'custom reason'
+                this.serverStream.on('error', () => {})
+                this.serverStream.destroy(error)
+            })
+        })
+
+        describe(webSocketName + ' "close" event', function () {
+            it('is emitted with code 1000 and reason "stream end" on clientStream.end()', function (done) {
+                this[webSocketName].on('close', (code, reason) => {
+                    assert.equal(code, NORMAL_CLOSURE_CODE)
+                    assert.equal(reason, 'stream end')
+                    done()
+                })
+                this.clientStream.end()
+            })
+            it('is emitted with code 1000 and reason "stream end" on serverStream.end()', function (done) {
+                this[webSocketName].on('close', (code, reason) => {
+                    assert.equal(code, NORMAL_CLOSURE_CODE)
+                    assert.equal(reason, 'stream end')
+                    done()
+                })
+                this.serverStream.end()
+            })
+            it('is emitted with code 1005 and reason "" on clientStream.destroy()', function (done) {
+                this[webSocketName].on('close', (code, reason) => {
+                    assert.equal(code, NO_STATUS_CODE)
+                    assert.equal(reason, '')
+                    done()
+                })
+                this.clientStream.destroy()
+            })
+            it('is emitted with code 1005 and reason "" on serverStream.destroy()', function (done) {
+                this[webSocketName].on('close', (code, reason) => {
+                    assert.equal(code, NO_STATUS_CODE)
+                    assert.equal(reason, '')
+                    done()
+                })
+                this.serverStream.destroy()
+            })
+            it('is emitted with code 1011 and reason "stream error" on clientStream.destroy(error)', function (done) {
+                this[webSocketName].on('close', (code, reason) => {
+                    assert.equal(code, INTERNAL_ERROR_CODE)
+                    assert.equal(reason, 'stream error')
+                    done()
+                })
+                const error = new Error('Test error')
+                this.clientStream.on('error', () => {})
+                this.clientStream.destroy(error)
+            })
+            it('is emitted with code 1011 and reason "stream error" on serverStream.destroy(error)', function (done) {
+                this[webSocketName].on('close', (code, reason) => {
+                    assert.equal(code, INTERNAL_ERROR_CODE)
+                    assert.equal(reason, 'stream error')
+                    done()
+                })
+                const error = new Error('Test error')
+                this.serverStream.on('error', () => {})
+                this.serverStream.destroy(error)
+            })
+            it('is emitted with code from error.closeCode on clientStream.destroy(error)', function (done) {
+                this[webSocketName].on('close', (code) => {
+                    assert.equal(code, CUSTOM_CODE)
+                    done()
+                })
+                const error = new Error('Test error')
+                error.closeCode = CUSTOM_CODE
+                this.clientStream.on('error', () => {})
+                this.clientStream.destroy(error)
+            })
+            it('is emitted with code from error.closeCode on serverStream.destroy(error)', function (done) {
+                this[webSocketName].on('close', (code) => {
+                    assert.equal(code, CUSTOM_CODE)
+                    done()
+                })
+                const error = new Error('Test error')
+                error.closeCode = CUSTOM_CODE
+                this.serverStream.on('error', () => {})
+                this.serverStream.destroy(error)
+            })
+            it('is emitted with reason from error.closeReason on clientStream.destroy(error)', function (done) {
+                this[webSocketName].on('close', (code, reason) => {
+                    assert.equal(reason, 'custom reason')
+                    done()
+                })
+                const error = new Error('Test error')
+                error.closeReason = 'custom reason'
+                this.clientStream.on('error', () => {})
+                this.clientStream.destroy(error)
+            })
+            it('is emitted with reason from error.closeReason on serverStream.destroy(error)', function (done) {
+                this[webSocketName].on('close', (code, reason) => {
+                    assert.equal(reason, 'custom reason')
+                    done()
+                })
+                const error = new Error('Test error')
+                error.closeReason = 'custom reason'
+                this.serverStream.on('error', () => {})
+                this.serverStream.destroy(error)
+            })
+        })
     })
 }


### PR DESCRIPTION
Add support for differentiating between different types of WebSocket closures by passing `code` and `reason` values to `ws.close()`. This is helpful, because a client may wish to perform different reconnection logic depending on the reason for disconnection.

In particular, it is useful to be able to differentiate intentional disconnections where the server wishes to indicate to the client that it should not reconnect at all or the client should delay for a more extended time before it reconnects. If, for example, a client's application version is no longer supported, the server may wish to disconnect with a reason that indicates the client should not attempt reconnection and it should refresh or update its code first.

In addition, this PR includes a full shim of Node's `stream.destroy()`, borrowed from current master of Node. The minimal shim was not consistent with the current implementation of stream.destroy() in Node 8+, particularly because it didn't emit passed in errors as an 'error' event. If we're shimming this, I believe we should use the full implementation from current Node for more consistency in API.

Including a shim of `stream.destroy()` is a key part of this PR, since it now produces a different close code than `stream.end()`